### PR TITLE
fix issue with LINUX_COMPILER formatting

### DIFF
--- a/scripts/mkcompile_h
+++ b/scripts/mkcompile_h
@@ -83,9 +83,10 @@ UTS_TRUNCATE="cut -b -$UTS_LEN"
   fi
   
   LD_VERSION=$($LD -v | head -n1 | sed 's/(compatible with [^)]*)//' \
-		      | sed 's/[[:space:]]*$//')
-
-  printf '#define LINUX_COMPILER "%s"\n' "$CC_VERSION, $LD_VERSION"
+          | sed 's/[[:space:]]*$//')
+  # remove new line at the end of CC_VERSION
+  CC_VERSION=$(echo $CC_VERSION | sed 's/[[:space:]]*$//')
+  echo "#define LINUX_COMPILER \"$CC_VERSION, $LD_VERSION\""
 ) > .tmpcompile
 
 # Only replace the real compile.h if the new one is different,

--- a/scripts/mkcompile_h
+++ b/scripts/mkcompile_h
@@ -68,22 +68,20 @@ UTS_TRUNCATE="cut -b -$UTS_LEN"
 
 # Generate a temporary compile.h
 
-( echo /\* This file is auto generated, version $VERSION \*/
+(
+  echo /\* This file is auto generated, version "$VERSION" \*/
+
   if [ -n "$CONFIG_FLAGS" ] ; then echo "/* $CONFIG_FLAGS */"; fi
-
-  echo \#define UTS_MACHINE \"$ARCH\"
-
-  echo \#define UTS_VERSION \"`echo $UTS_VERSION | $UTS_TRUNCATE`\"
-
-  echo \#define LINUX_COMPILE_BY \"`echo $LINUX_COMPILE_BY | $UTS_TRUNCATE`\"
-  echo \#define LINUX_COMPILE_HOST \"`echo $LINUX_COMPILE_HOST | $UTS_TRUNCATE`\"
-
+  echo \#define UTS_MACHINE \""$ARCH"\"
+  echo \#define UTS_VERSION \""$(echo "$UTS_VERSION" | $UTS_TRUNCATE)"\"
+  echo \#define LINUX_COMPILE_BY \""$(echo "$LINUX_COMPILE_BY" | $UTS_TRUNCATE)"\"
+  echo \#define LINUX_COMPILE_HOST \""$(echo "$LINUX_COMPILE_HOST" | $UTS_TRUNCATE)"\"
   if [ -z "$KBUILD_COMPILER_STRING" ]; then
     CC_VERSION=$($CC -v 2>&1 | grep ' version ' | sed 's/[[:space:]]*$//')
   else
     CC_VERSION="$KBUILD_COMPILER_STRING"
   fi
-
+  
   LD_VERSION=$($LD -v | head -n1 | sed 's/(compatible with [^)]*)//' \
 		      | sed 's/[[:space:]]*$//')
 


### PR DESCRIPTION
found that the `LINUX_COMPILER` definition generated at `<out>/include/generated/compile.h` has an issue with formatting

a new line character in `CC_VERSION` crashed my compilation
and usage of backticks glitched my syntax highlighting 

made some changes to `scripts/mkcompile.h:71` to fix these issues

###### crash shot
![Screenshot 2023-06-05 104922](https://github.com/Exynos9611-Development/kernel_samsung_universal9611/assets/68287637/9665a40d-9fa5-44c5-8cdc-5480b5683463)
