### PR TITLE
kernel: sched: update from P615XXS7FXA1

### DIFF
--- a/include/linux/ems.h
+++ b/include/linux/ems.h
@@ -15,6 +15,8 @@
 #include <linux/sched/idle.h>
 #include <linux/sched/topology.h>
 
+struct rq;
+
 struct gb_qos_request {
 	struct plist_node node;
 	char *name;
@@ -50,6 +52,10 @@ extern int exynos_need_active_balance(enum cpu_idle_type idle,
 /* wakeup balance */
 extern int
 exynos_wakeup_balance(struct task_struct *p, int prev_cpu, int sd_flag, int sync);
+extern void update_last_waked_ns_task(struct task_struct *p);
+
+/* load balance */
+extern int frt_idle_pull_tasks(struct rq *dst_rq);
 
 /* ontime migration */
 extern void ontime_migration(void);
@@ -86,6 +92,12 @@ exynos_wakeup_balance(struct task_struct *p, int prev_cpu, int sd_flag, int sync
 	return -1;
 }
 
+static inline void update_last_waked_ns_task(struct task_struct *p) { }
+static inline int
+frt_idle_pull_tasks(struct rq *dst_rq)
+{
+	return -1;
+}
 static inline void ontime_migration(void) { }
 static inline int ontime_can_migration(struct task_struct *p, int cpu)
 {

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -725,6 +725,7 @@ struct task_struct {
 #endif
 #ifdef CONFIG_SCHED_USE_FLUID_RT
 	int victim_flag;
+	u64 last_waked_ns;
 #endif
 
 #ifdef CONFIG_SCHED_EMS

--- a/include/trace/events/sched.h
+++ b/include/trace/events/sched.h
@@ -731,6 +731,33 @@ TRACE_EVENT(sched_fluid_stat,
 		  __entry->util_avg,
 		  __entry->selectby)
 );
+
+TRACE_EVENT(sched_frt_idle_pull_tasks,
+
+	TP_PROTO(struct task_struct *tsk, int src_cpu, int dst_cpu),
+
+	TP_ARGS(tsk, src_cpu, dst_cpu),
+
+	TP_STRUCT__entry(
+		__array( char,	name,	TASK_COMM_LEN	)
+		__field( pid_t,	pid				)
+		__field( int,	src_cpu				)
+		__field( int,	dst_cpu				)
+	),
+
+	TP_fast_assign(
+		memcpy(__entry->name, tsk->comm, TASK_COMM_LEN);
+		__entry->pid			= tsk->pid;
+		__entry->src_cpu		= src_cpu;
+		__entry->dst_cpu		= dst_cpu;
+	),
+	TP_printk("frt: comm=%s pid=%d src_cpu=%d dst_cpu=%d",
+		  __entry->name,
+		  __entry->pid,
+		  __entry->src_cpu,
+		  __entry->dst_cpu)
+);
+
 /*
  * Tracepoint for accounting sched averages for tasks.
  */

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2116,6 +2116,9 @@ try_to_wake_up(struct task_struct *p, unsigned int state, int wake_flags,
 
 	walt_try_to_wake_up(p);
 
+	if (sched_feat(EXYNOS_MS))
+		update_last_waked_ns_task(p);
+
 	p->sched_contributes_to_load = !!task_contributes_to_load(p);
 	p->state = TASK_WAKING;
 

--- a/kernel/sched/ems/band.c
+++ b/kernel/sched/ems/band.c
@@ -12,8 +12,8 @@
 #include <linux/sched/signal.h>
 #include <trace/events/ems.h>
 
-#include "ems.h"
 #include "../sched.h"
+#include "ems.h"
 
 static struct task_band *lookup_band(struct task_struct *p)
 {

--- a/kernel/sched/ems/core.c
+++ b/kernel/sched/ems/core.c
@@ -7,12 +7,542 @@
 
 #include <linux/ems.h>
 
+#include "../sched.h"
+#include "../tune.h"
+#include "ems.h"
+
 #define CREATE_TRACE_POINTS
 #include <trace/events/ems.h>
 
-#include "ems.h"
-#include "../sched.h"
-#include "../tune.h"
+struct lb_env {
+	struct rq *src_rq;
+	struct rq *dst_rq;
+	struct task_struct *push_task;
+	u64 flags;
+};
+
+static struct lb_env __percpu *lb_env;
+static struct cpu_stop_work __percpu *lb_work;
+
+static struct cpumask slowest_mask;
+static struct cpumask fastest_mask;
+
+#define BUSIEST_EQUAL	0
+#define BUSIEST_SLOWER	1
+#define BUSIEST_FASTER	2
+
+#define TINY_TASK_RATIO_SHIFT	3	/* 12.5% */
+#define BUSY_GROUP_RATIO_SHIFT	2	/* 25% */
+#define NIB_AVG_IDLE_THRESHOLD	500000
+
+static bool is_per_cpu_ktask(struct task_struct *p)
+{
+	if (!(p->flags & PF_KTHREAD))
+		return false;
+
+	if (p->nr_cpus_allowed != 1)
+		return false;
+
+	return true;
+}
+
+static inline bool can_migrate(struct task_struct *p, int dst_cpu)
+{
+	if (p->exit_state)
+		return false;
+
+	if (is_per_cpu_ktask(p))
+		return false;
+
+#ifdef CONFIG_SMP
+	if (task_running(NULL, p))
+		return false;
+#endif
+
+	if (!cpumask_test_cpu(dst_cpu, &p->cpus_allowed))
+		return false;
+
+	return cpu_active(dst_cpu);
+}
+
+void attach_task(struct rq *dst_rq, struct task_struct *p)
+{
+	activate_task(dst_rq, p, ENQUEUE_NOCLOCK);
+	p->on_rq = TASK_ON_RQ_QUEUED;
+	check_preempt_curr(dst_rq, p, 0);
+}
+
+void attach_one_task(struct rq *dst_rq, struct task_struct *p)
+{
+	struct rq_flags rf;
+
+	rq_lock(dst_rq, &rf);
+	update_rq_clock(dst_rq);
+	attach_task(dst_rq, p);
+	rq_unlock(dst_rq, &rf);
+}
+
+void detach_task(struct rq *src_rq, struct rq *dst_rq, struct task_struct *p,
+		struct rq_flags *rf)
+{
+	p->on_rq = TASK_ON_RQ_MIGRATING;
+	deactivate_task(src_rq, p, DEQUEUE_NOCLOCK);
+	rq_unpin_lock(src_rq, rf);
+	double_lock_balance(src_rq, dst_rq);
+	set_task_cpu(p, dst_rq->cpu);
+	double_unlock_balance(src_rq, dst_rq);
+	rq_unpin_lock(src_rq, rf);
+}
+
+int detach_one_task(struct rq *src_rq, struct rq *dst_rq,
+		struct task_struct *target, struct rq_flags *rf)
+{
+	struct task_struct *p, *n;
+
+	list_for_each_entry_safe(p, n, &src_rq->cfs_tasks, se.group_node) {
+		if (p != target)
+			continue;
+
+		if (!can_migrate(p, dst_rq->cpu))
+			break;
+
+		update_rq_clock(src_rq);
+		detach_task(src_rq, dst_rq, p, rf);
+		return 1;
+	}
+
+	return 0;
+}
+
+static bool determine_short_idle(u64 avg_idle)
+{
+	return avg_idle < NIB_AVG_IDLE_THRESHOLD;
+}
+
+static unsigned long cpu_util_total(int cpu)
+{
+	struct cfs_rq *cfs_rq = &cpu_rq(cpu)->cfs;
+	struct rt_rq *rt_rq = &cpu_rq(cpu)->rt;
+	unsigned long util = READ_ONCE(cfs_rq->avg.util_avg) + READ_ONCE(rt_rq->avg.util_avg);
+
+	return util;
+}
+
+/*
+ * This function called when src rq has only one task,
+ * and need to check whether need an active balance or not
+ */
+bool lb_queue_need_active_mgt(struct rq *src, struct rq *dst)
+{
+	if (!src->misfit_task_load)
+		return false;
+
+	return true;
+}
+
+bool lb_busiest_queue_pre_condition(struct rq *rq, bool check_overutil)
+{
+	/* if there is no fair task, we can't balance */
+	if (!rq->cfs.h_nr_running)
+		return false;
+
+	/* if rq is in the active balance, will be less busy */
+	if (rq->active_balance)
+		return false;
+
+	if (check_overutil && !lbt_overutilized(cpu_of(rq), 0))
+		return false;
+
+	return true;
+}
+
+bool lb_group_is_busy(struct cpumask *cpus,
+			int nr_task, unsigned long util)
+{
+	unsigned long capacity = capacity_orig_of(cpumask_first(cpus));
+	int nr_cpus = cpumask_weight(cpus);
+	/*
+	 * if there is a available cpu in the group,
+	 * this group is not busy
+	 */
+	if (nr_task <= nr_cpus)
+		return false;
+
+	if ((util + (util >> BUSY_GROUP_RATIO_SHIFT)) < (capacity * nr_cpus))
+		return false;
+
+	return true;
+}
+
+static void lb_find_busiest_faster_queue(int dst_cpu,
+		struct cpumask *src_cpus, struct rq **busiest)
+{
+	int src_cpu, busiest_cpu = -1;
+	struct cpumask candidate_mask;
+	unsigned long util, busiest_util = 0;
+	unsigned long util_sum = 0, nr_task_sum = 0;
+	unsigned long tiny_task_util;
+
+	tiny_task_util = capacity_orig_of(cpumask_first(src_cpus)) >> TINY_TASK_RATIO_SHIFT;
+	cpumask_and(&candidate_mask, src_cpus, cpu_active_mask);
+	if (cpumask_empty(&candidate_mask))
+		return;
+
+	for_each_cpu(src_cpu, &candidate_mask) {
+		struct rq *src_rq = cpu_rq(src_cpu);
+
+		trace_lb_cpu_util(src_cpu, "faster");
+
+		util = cpu_util_total(src_cpu);
+		util_sum += util;
+		nr_task_sum += src_rq->cfs.h_nr_running;
+
+		if (!lb_busiest_queue_pre_condition(src_rq, true))
+			continue;
+
+		if (src_rq->cfs.h_nr_running < 2)
+			continue;
+
+		if (src_rq->cfs.h_nr_running == 2 &&
+			util < tiny_task_util)
+			continue;
+
+		if (util < busiest_util)
+			continue;
+
+		busiest_util = util;
+		busiest_cpu = src_cpu;
+	}
+
+	/*
+	 * Don't allow migrating to lower cluster unless
+	 * this faster cluster is sufficiently loaded.
+	 */
+	if (!lb_group_is_busy(&candidate_mask, nr_task_sum, util_sum))
+		return;
+
+	if (busiest_cpu != -1)
+		*busiest = cpu_rq(busiest_cpu);
+}
+
+static void lb_find_busiest_slower_queue(int dst_cpu,
+		struct cpumask *src_cpus, struct rq **busiest)
+{
+	int src_cpu, busiest_cpu = -1;
+	unsigned long util, busiest_util = 0;
+
+
+	for_each_cpu_and(src_cpu, src_cpus, cpu_active_mask) {
+		struct rq *src_rq = cpu_rq(src_cpu);
+
+		trace_lb_cpu_util(src_cpu, "slower");
+
+		if (!lb_busiest_queue_pre_condition(src_rq, true))
+			continue;
+
+		if (src_rq->cfs.h_nr_running == 1 &&
+			!lb_queue_need_active_mgt(src_rq, cpu_rq(dst_cpu)))
+			continue;
+
+		util = cpu_util_total(src_cpu);
+		if (util < busiest_util)
+			continue;
+
+		busiest_util = util;
+		busiest_cpu = src_cpu;
+	}
+
+	if (busiest_cpu != -1)
+		*busiest = cpu_rq(busiest_cpu);
+}
+
+static void lb_find_busiest_equivalent_queue(int dst_cpu,
+		struct cpumask *src_cpus, struct rq **busiest)
+{
+	int src_cpu, busiest_cpu = -1;
+	unsigned long util, busiest_util = 0;
+
+	for_each_cpu_and(src_cpu, src_cpus, cpu_active_mask) {
+		struct rq *src_rq = cpu_rq(src_cpu);
+
+		trace_lb_cpu_util(src_cpu, "equal");
+
+		if (src_cpu == dst_cpu)
+			continue;
+
+		if (!lb_busiest_queue_pre_condition(src_rq, false))
+			continue;
+
+		if (src_rq->nr_running < 2)
+			continue;
+
+		/* find highest util cpu */
+		util = cpu_util_total(src_cpu);
+		if (util < busiest_util)
+			continue;
+
+		busiest_util = util;
+		busiest_cpu = src_cpu;
+	}
+
+	if (busiest_cpu != -1)
+		*busiest = cpu_rq(busiest_cpu);
+}
+
+static void __lb_find_busiest_queue(int dst_cpu,
+		struct cpumask *src_cpus, struct rq **busiest, int *type)
+{
+	unsigned long dst_capacity, src_capacity;
+
+	src_capacity = capacity_orig_of(cpumask_first(src_cpus));
+	dst_capacity = capacity_orig_of(dst_cpu);
+	if (dst_capacity == src_capacity) {
+		lb_find_busiest_equivalent_queue(dst_cpu, src_cpus, busiest);
+		*type = BUSIEST_EQUAL;
+	} else if (dst_capacity > src_capacity) {
+		lb_find_busiest_slower_queue(dst_cpu, src_cpus, busiest);
+		*type = BUSIEST_SLOWER;
+	} else {
+		lb_find_busiest_faster_queue(dst_cpu, src_cpus, busiest);
+		*type = BUSIEST_FASTER;
+	}
+}
+
+static int lb_active_migration_stop(void *data)
+{
+	struct lb_env *env = data;
+	struct rq *src_rq = env->src_rq, *dst_rq = env->dst_rq;
+	struct rq_flags rf;
+	int ret;
+
+	rq_lock_irq(src_rq, &rf);
+	ret = detach_one_task(src_rq, dst_rq, env->push_task, &rf);
+	src_rq->active_balance = 0;
+	rq_unlock(src_rq, &rf);
+
+	if (ret)
+		attach_one_task(dst_rq, env->push_task);
+
+	local_irq_enable();
+
+	return 0;
+}
+
+static bool _lb_can_migrate_task(struct task_struct *p, int src_cpu, int dst_cpu)
+{
+	if (!ontime_can_migration(p, dst_cpu)) {
+		trace_lb_can_migrate_task(p, dst_cpu, false, "ontime");
+		return false;
+	}
+
+	if (!cpumask_test_cpu(dst_cpu, tsk_cpus_allowed(p))) {
+		trace_lb_can_migrate_task(p, dst_cpu, false, "cpus-allowed");
+		return false;
+	}
+
+	trace_lb_can_migrate_task(p, dst_cpu, true, "can-migrate");
+
+	return true;
+}
+
+static bool lb_task_need_active_mgt(struct task_struct *p, int dst_cpu, int src_cpu)
+{
+	struct rq *src_rq = cpu_rq(src_cpu);
+
+	if (capacity_orig_of(dst_cpu) <= capacity_orig_of(src_cpu))
+		return false;
+
+	if (!src_rq->misfit_task_load)
+		return false;
+
+	return true;
+}
+
+static int lb_idle_pull_tasks(int dst_cpu, int src_cpu, int type)
+{
+	struct lb_env *env = per_cpu_ptr(lb_env, src_cpu);
+	struct rq *dst_rq = cpu_rq(dst_cpu);
+	struct rq *src_rq = cpu_rq(src_cpu);
+	struct task_struct *pulled_task = NULL, *p;
+	bool active_balance = false;
+	struct rq_flags rf;
+	int util, min_util = INT_MAX, count = 0;
+
+	rq_lock_irqsave(src_rq, &rf);
+	list_for_each_entry_reverse(p, &src_rq->cfs_tasks, se.group_node) {
+		if (!_lb_can_migrate_task(p, src_cpu, dst_cpu))
+			continue;
+
+		if (task_running(src_rq, p))
+			if (!lb_task_need_active_mgt(p, dst_cpu, src_cpu))
+				continue;
+
+		if (!can_migrate(p, dst_cpu))
+			continue;
+
+		if (type != BUSIEST_FASTER) {
+			pulled_task = p;
+			break;
+		}
+
+		/* find min util cpu */
+		util = task_util(p);
+		if (util > min_util)
+			continue;
+
+		min_util = util;
+		pulled_task = p;
+		if (++count > 3)
+			break;
+	}
+
+	if (!pulled_task) {
+		rq_unlock_irqrestore(src_rq, &rf);
+		return 0;
+	}
+
+	if (task_running(src_rq, pulled_task)) {
+		active_balance = true;
+	} else {
+		update_rq_clock(src_rq);
+		detach_task(src_rq, dst_rq, pulled_task, &rf);
+	}
+
+	if (active_balance) {
+		if (src_rq->active_balance) {
+			rq_unlock_irqrestore(src_rq, &rf);
+			return 0;
+		}
+
+		src_rq->active_balance = true;
+		env->src_rq = src_rq;
+		env->dst_rq = dst_rq;
+		env->push_task = pulled_task;
+
+		/* lock must be dropped before waking the stopper */
+		rq_unlock_irqrestore(src_rq, &rf);
+
+		trace_lb_active_migration(p, src_cpu, dst_cpu, "idle");
+		stop_one_cpu_nowait(src_cpu, lb_active_migration_stop,
+				env, per_cpu_ptr(lb_work, src_cpu));
+
+		/* we did not pull any task here */
+		return 0;
+	}
+
+	raw_spin_unlock(&src_rq->lock);
+
+	attach_one_task(dst_rq, pulled_task);
+
+	local_irq_restore(rf.flags);
+
+	return 1;
+}
+
+struct rq *lb_find_busiest_queue(struct rq *dst_rq, int *type)
+{
+	struct rq *busiest = NULL;
+	int dst_cpu = dst_rq->cpu;
+
+	/* if this rq has a task, stop idle-pull */
+	if (dst_rq->nr_running > 0)
+		goto out;
+
+	if (cpumask_test_cpu(dst_cpu, &slowest_mask)) {
+		__lb_find_busiest_queue(dst_cpu, &slowest_mask, &busiest, type);
+		if (busiest)
+			goto out;
+
+		__lb_find_busiest_queue(dst_cpu, &fastest_mask, &busiest, type);
+	} else {
+		__lb_find_busiest_queue(dst_cpu, &fastest_mask, &busiest, type);
+		if (busiest)
+			goto out;
+
+		__lb_find_busiest_queue(dst_cpu, &slowest_mask, &busiest, type);
+	}
+out:
+	return busiest;
+}
+
+void lb_newidle_balance(struct rq *dst_rq, struct rq_flags *rf,
+				int *pulled_task, struct sched_domain *sd)
+{
+	int dst_cpu = dst_rq->cpu;
+	bool short_idle;
+	struct rq *busiest = NULL;
+	int type, src_cpu = -1;
+
+	dst_rq->misfit_task_load = 0;
+	short_idle = determine_short_idle(dst_rq->avg_idle);
+	dst_rq->idle_stamp = rq_clock(dst_rq);
+
+	/*
+	 * Do not pull tasks towards !active CPUs...
+	 */
+	if (!cpu_active(dst_cpu))
+		return;
+
+	if (cpumask_empty(&slowest_mask) || cpumask_empty(&fastest_mask))
+		return;
+
+	rq_unpin_lock(dst_rq, rf);
+
+	/* to check ttwu_pending */
+	if (!llist_empty(&dst_rq->wake_list))
+		goto out;
+
+	if (dst_rq->nr_running)
+		goto out;
+
+	if (frt_idle_pull_tasks(dst_rq))
+		goto out;
+
+	/* sanity check again after drop rq lock during RT balance */
+	if (dst_rq->nr_running)
+		goto out;
+
+	if (!READ_ONCE(dst_rq->rd->overload))
+		goto out;
+
+	if (atomic_read(&dst_rq->nr_iowait) && short_idle)
+		goto out;
+
+	raw_spin_unlock(&dst_rq->lock);
+
+	busiest = lb_find_busiest_queue(dst_rq, &type);
+	if (busiest) {
+		src_cpu = cpu_of(busiest);
+		if (dst_cpu != src_cpu)
+			*pulled_task = lb_idle_pull_tasks(dst_cpu, src_cpu, type);
+	}
+
+	raw_spin_lock(&dst_rq->lock);
+out:
+	/*
+	 * While browsing the domains, we released the rq lock, a task could
+	 * have been enqueued in the meantime. Since we're not going idle,
+	 * pretend we pulled a task.
+	 */
+	if (dst_rq->cfs.h_nr_running && !*pulled_task)
+		*pulled_task = 1;
+
+	/* Is there a task of a high priority class? */
+	if (dst_rq->nr_running != dst_rq->cfs.h_nr_running)
+		*pulled_task = -1;
+
+	if (*pulled_task)
+		dst_rq->idle_stamp = 0;
+
+	rq_repin_lock(dst_rq, rf);
+
+	trace_lb_newidle_balance(dst_cpu, src_cpu, *pulled_task, short_idle);
+}
+
+void update_last_waked_ns_task(struct task_struct *p)
+{
+	p->last_waked_ns = ktime_get_ns();
+}
 
 unsigned long cpu_util(int cpu)
 {
@@ -349,11 +879,33 @@ out:
 	return target_cpu;
 }
 
+const struct cpumask *cpu_slowest_mask(void)
+{
+	return &slowest_mask;
+}
+
+const struct cpumask *cpu_fastest_mask(void)
+{
+	return &fastest_mask;
+}
+
+static void cpumask_speed_init(void)
+{
+	cpumask_clear(&slowest_mask);
+	cpumask_clear(&fastest_mask);
+	cpumask_copy(&slowest_mask, cpu_coregroup_mask(0));
+	cpumask_copy(&fastest_mask, cpu_coregroup_mask(4));
+}
+
 struct kobject *ems_kobj;
 
 static int __init init_sysfs(void)
 {
+	cpumask_speed_init();
 	ems_kobj = kobject_create_and_add("ems", kernel_kobj);
+
+	lb_env = alloc_percpu(struct lb_env);
+	lb_work = alloc_percpu(struct cpu_stop_work);
 
 	return 0;
 }

--- a/kernel/sched/ems/ems.h
+++ b/kernel/sched/ems/ems.h
@@ -10,7 +10,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-
 #include "../sched-pelt.h"
 
 #define cpu_selected(cpu)	(cpu >= 0)
@@ -26,6 +25,7 @@ extern int global_boosted(void);
 extern int select_energy_cpu(struct task_struct *p, int prev_cpu, int sd_flag, int sync);
 extern unsigned int calculate_energy(struct task_struct *p, int target_cpu);
 extern int band_play_cpu(struct task_struct *p);
+extern int ontime_can_migration(struct task_struct *p, int dst_cpu);
 
 #ifdef CONFIG_SCHED_TUNE
 extern int prefer_perf_cpu(struct task_struct *p);

--- a/kernel/sched/ems/energy.c
+++ b/kernel/sched/ems/energy.c
@@ -8,8 +8,8 @@
 #include <linux/cpufreq.h>
 #include <trace/events/ems.h>
 
-#include "ems.h"
 #include "../sched.h"
+#include "ems.h"
 
 /*
  * The compute capacity, power consumption at this compute capacity and

--- a/kernel/sched/ems/global_boost.c
+++ b/kernel/sched/ems/global_boost.c
@@ -11,6 +11,7 @@
 
 #include <trace/events/ems.h>
 
+#include "../sched.h"
 #include "ems.h"
 
 /*

--- a/kernel/sched/ems/init_util.c
+++ b/kernel/sched/ems/init_util.c
@@ -6,9 +6,10 @@
  */
 
 #include <linux/sched.h>
+#include <linux/ems.h>
 
-#include "ems.h"
 #include "../sched.h"
+#include "ems.h"
 
 enum {
 	TYPE_BASE_CFS_RQ_UTIL = 0,
@@ -69,6 +70,8 @@ void exynos_init_entity_util_avg(struct sched_entity *se)
 		pr_info("%s: Not support initial util type %ld\n",
 				__func__, init_util_type);
 	}
+
+	update_last_waked_ns_task(task_of(se));
 }
 
 static ssize_t show_initial_util_type(struct kobject *kobj,

--- a/kernel/sched/ems/pcf.c
+++ b/kernel/sched/ems/pcf.c
@@ -7,8 +7,8 @@
 
 #include <trace/events/ems.h>
 
-#include "ems.h"
 #include "../sched.h"
+#include "ems.h"
 
 /*
  * Currently, PCF is composed of a selection algorithm based on distributed

--- a/kernel/sched/ems/st_addon.c
+++ b/kernel/sched/ems/st_addon.c
@@ -10,9 +10,9 @@
 #include <linux/ems.h>
 #include <trace/events/ems.h>
 
-#include "ems.h"
 #include "../sched.h"
 #include "../tune.h"
+#include "ems.h"
 
 /**********************************************************************
  *                            Prefer Perf                             *

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -10845,6 +10845,11 @@ update_next_balance(struct sched_domain *sd, unsigned long *next_balance)
  * idle_balance is called by schedule() if this_cpu is about to become
  * idle. Attempts to pull tasks from other CPUs.
  */
+#ifdef CONFIG_SCHED_EMS
+extern void lb_newidle_balance(struct rq *dst_rq, struct rq_flags *rf,
+				int *pulled_task, struct sched_domain *sd);
+#endif
+
 static int idle_balance(struct rq *this_rq, struct rq_flags *rf)
 {
 	unsigned long next_balance = jiffies + HZ;
@@ -10852,6 +10857,12 @@ static int idle_balance(struct rq *this_rq, struct rq_flags *rf)
 	struct sched_domain *sd;
 	int pulled_task = 0;
 	u64 curr_cost = 0;
+
+	if (sched_feat(EXYNOS_MS)) {
+		lb_newidle_balance(this_rq, rf, &pulled_task, sd);
+		if (pulled_task)
+			return pulled_task;
+	}
 
 	/*
 	 * We must set idle_stamp _before_ calling idle_balance(), such that we

--- a/kernel/sched/rt.c
+++ b/kernel/sched/rt.c
@@ -158,6 +158,71 @@ static const struct attribute_group frt_group = {
 	.attrs = frt_attrs,
 };
 
+static struct task_struct *pick_highest_pushable_task(struct rq *rq, int cpu);
+static inline int has_pushable_tasks(struct rq *rq);
+
+#define MIN_RUNNABLE_THRESHOLD	(500000)
+static bool frt_short_runnable(struct task_struct *p)
+{
+	return ktime_get_ns() - p->last_waked_ns < MIN_RUNNABLE_THRESHOLD;
+}
+
+static bool frt_sched_runnable(struct rq *rq)
+{
+	return rq->rt.rt_queued > 0;
+}
+
+int frt_idle_pull_tasks(struct rq *dst_rq)
+{
+	struct rq *src_rq;
+	struct task_struct *pulled_task;
+	int cpu, src_cpu = -1, dst_cpu = dst_rq->cpu, ret = 0;
+
+	if (frt_sched_runnable(dst_rq))
+		return 0;
+
+	for_each_possible_cpu(cpu) {
+		if (has_pushable_tasks(cpu_rq(cpu))) {
+			src_cpu = cpu;
+			break;
+		}
+	}
+
+	if (src_cpu == -1)
+		return 0;
+
+	if (src_cpu == dst_cpu)
+		return 0;
+
+	src_rq = cpu_rq(src_cpu);
+	double_lock_balance(dst_rq, src_rq);
+
+	if (frt_sched_runnable(dst_rq))
+		goto out;
+
+	pulled_task = pick_highest_pushable_task(src_rq, dst_cpu);
+	if (!pulled_task)
+		goto out;
+
+	if (frt_short_runnable(pulled_task))
+		goto out;
+
+	deactivate_task(src_rq, pulled_task, 0);
+	pulled_task->on_rq = TASK_ON_RQ_MIGRATING;
+	set_task_cpu(pulled_task, dst_cpu);
+	pulled_task->on_rq = TASK_ON_RQ_QUEUED;
+	activate_task(dst_rq, pulled_task, 0);
+	ret = 1;
+
+out:
+	if (ret)
+		trace_sched_frt_idle_pull_tasks(pulled_task, src_cpu, dst_cpu);
+
+	double_unlock_balance(dst_rq, src_rq);
+
+	return ret;
+}
+
 static int frt_find_prefer_cpu(struct task_struct *task)
 {
 	int cpu, allowed_cpu = 0;


### PR DESCRIPTION
Tests: build completed successfully without issues, tested on A51. Should be tested on the other devices as well but since the are all 9611 there should not be any issues.

This update is from Tab S6 Lite 2020 which has the most up-to-date Samsung kernel so implement changes also on other 9611 devices, because may be the last update for scheduler too. 

I'll try to update other Samsung specific components with other PR. 